### PR TITLE
fix: update node version in gha

### DIFF
--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           always-auth: true
-          node-version: 12
+          node-version: 20
           registry-url: "https://npm.pkg.github.com/promotedai"
           scope: "@promotedai"
 


### PR DESCRIPTION
The npm package uses 20 so I went with 20.  LTS is 18 but will soon be 20.

TESTING=none